### PR TITLE
Support input from serial sources on Windows

### DIFF
--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -864,7 +864,7 @@ def lines_from_source(source):
     if isinstance(source, TextIOBase):
         for line in source:
             yield line
-    elif re.match("/dev/tty.*", source):
+    elif re.match("/dev/tty.*", source) or re.match("COM\\d+$", source):
         yield from _handle_serial_source(source)
     elif re.match("https?://.*", source):
         yield from _handle_url_source(source)


### PR DESCRIPTION
On Windows, serial ports are named COMn, where n is a number from 1 to 100+.

To support input from COM ports, I've added a regexp to the if statement that already detects and handles /dev/tty* sources.
