### PR TITLE
fix lon/lat in msg type 27, possibly now also works in types 17 and 22

### DIFF
--- a/devtools/aivdm_translate.py
+++ b/devtools/aivdm_translate.py
@@ -135,8 +135,10 @@ message_types = Table(soup.find('h2', {'id': '_ais_payload_interpretation'}).fin
 
 messages = extract_message_types(soup, message_types)
 
-# fix error in source; text says (and data confirms) it's an enum
-messages["19"]["fields"][13]["type"] = "e"
+# fix errors in source
+messages["19"]["fields"][13]["type"] = "e"  # text says (and data confirms) it's an enum
+messages["27"]["fields"][6]["type"] = "I1"
+messages["27"]["fields"][7]["type"] = "I1"
 
 lookups = extract_lookups(soup)
 

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -442,10 +442,10 @@ class BitFieldDecoder(FieldDecoder):
             return self._parse_lon
         elif name == 'lat' and data_type == 'I4':
             return self._parse_lat
-        elif name == 'lon' and data_type == 'I1':
-            return lambda b: None  # Type 17 is weird; ignore for now
-        elif name == 'lat' and data_type == 'I1':
-            return lambda b: None  # Type 17 is weird; ignore for now
+        elif name.endswith('lon') and data_type == 'I1':
+            return self._parse_lon_coarse
+        elif name.endswith('lat') and data_type == 'I1':
+            return self._parse_lat_coarse
         elif data_type == 't' or data_type == 's':
             return self._parse_text
         elif data_type == 'I1':
@@ -506,6 +506,20 @@ class BitFieldDecoder(FieldDecoder):
         if not payload.has_bits(self.start, self.end + 1):
             return None
         result = payload.scaled_int_for_bit_range(self.start, self.end + 1, 4)
+        if result is not None and result != 91.0 and -90.0 <= result <= 90.0:
+            return result
+
+    def _parse_lon_coarse(self, payload):
+        if not payload.has_bits(self.start, self.end + 1):
+            return None
+        result = payload.scaled_int_for_bit_range(self.start, self.end + 1, 1)
+        if result is not None and result != 181.0 and -180.0 <= result <= 180.0:
+            return result
+
+    def _parse_lat_coarse(self, payload):
+        if not payload.has_bits(self.start, self.end + 1):
+            return None
+        result = payload.scaled_int_for_bit_range(self.start, self.end + 1, 1)
         if result is not None and result != 91.0 and -90.0 <= result <= 90.0:
             return result
 

--- a/simpleais/aivdm.json
+++ b/simpleais/aivdm.json
@@ -2574,14 +2574,14 @@
                     "end": 61,
                     "description": "Longitude",
                     "member": "lon",
-                    "type": "I4"
+                    "type": "I1"
                 },
                 {
                     "start": 62,
                     "end": 78,
                     "description": "Latitude",
                     "member": "lat",
-                    "type": "I4"
+                    "type": "I1"
                 },
                 {
                     "start": 79,

--- a/tests/test_field_lookup.py
+++ b/tests/test_field_lookup.py
@@ -98,13 +98,11 @@ class TestFieldLookup(TestCase):
         self.assertFalse(m['unknown'])
 
     def test_type_17_location(self):
-        # Type 17 locations are weird. I don't have enough data to reliably check,
-        # and it's not clear that it means the same thing as other lon/lat fields.
-        # So we'll just ignore them.
+        # not sure where this example came from, so I'm not totally sure it's right, but it seems to work
         m = parse(['!AIVDM,2,1,2,B,AkklHKotBpj>Pv8OptkMaD`J4:iU74U5807A6AQaM`;,0*45',
                    '!AIVDM,2,2,2,B,wibCPG`kAfs:E0Dhp,0*73'])[0]
-        self.assertIsNone(m['lat'])
-        self.assertIsNone(m['lon'])
+        self.assertEqual(m['lat'], 42.86)
+        self.assertEqual(m['lon'], -6.3233)
 
     def test_type_5(self):
         m = parse(['!AIVDM,2,1,8,A,55Mw0BP00001L=WKC?98uT4j1=@580000000000t1@D5540Ht6?UDp4iSp=<,0*74',
@@ -138,6 +136,10 @@ class TestFieldLookup(TestCase):
         m = parse('1456614528.900 !AIVDM,1,1,,B,4r`r4cc2tMhKpNFJtl1>Egqo1<9l,0*2C')
         self.assertIsNone(m['time'])
 
+    def test_type_27_location(self):
+        m = parse('!AIVDM,1,1,,A,KCQ9r=hrFUnH7P00,0*41')
+        self.assertEqual(m['lon'], -154.2017)
+        self.assertEqual(m['lat'], 87.065)
 
 # this test is a sign of a terrible design problem. TODO: maybe make enum collections responsible for defaulting?
 class TestEnumLookup(TestCase):


### PR DESCRIPTION
While I'm at it, this pull request fixes lon/lat in message type 27 (long-range AIS) as reported in issue #2 

I guess you based the field definitions in the JSON file on the documentation for AIVDM available [here](https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_27_long_range_ais_broadcast_message). The documentation is inconsistent between data types and description for the lon/lat fields. The data type for lon/lat should be `I1` instead of `I4` as the values are in minutes/10. 

I've added `_parse_lon_coarse` and `_parse_lat_coarse` to decode fields of data type `I1` and a name ending with "lon" or "lat" respectively. "Ending with" because message type 22 has fields named "ne_lon", "ne_lat", "sw_lon" and "sw_lat", also of data type `I1` .

I only have example messages to test with type 27, but lon/lat fields should now also work for message types 17 and 22.

Type 27 messages used for testing:
```
!AIVDM,1,1,,A,KCQ9r=hrFUnH7P00,0*41
!AIVDM,1,1,,B,KC5E2b@U19PFdLbMuc5=ROv62<7m,0*16
!AIVDM,1,1,,B,K5DfMB9FLsM?P00d,0*70
```
Output of `aisdump` agrees with the online decoder by Maritec available [here](https://www.maritec.co.za/tools/aisvdmvdodecoding).

```
Sentence 1:
          text: !AIVDM,1,1,,A,KCQ9r=hrFUnH7P00,0*41
        length: 96
          type: 27
        repeat: 1
          mmsi: 236091959
      accuracy: 0
          raim: 0
        status: 3
           lon: -154.2017
           lat: 87.065
         speed: 0
        course: 0
          gnss: 0
    ignored-95: 0

Sentence 2:
          text: !AIVDM,1,1,,A,KC5E2b@U19PFdLbMuc5=ROv62<7m,0*15
        length: 168
          type: 27
        repeat: 1
          mmsi: 206914217
      accuracy: 0
          raim: 0
        status: 2
           lon: 137.0233
           lat: 4.84
         speed: 57
        course: 167
          gnss: 0
    ignored-95: 1

Sentence 3:
          text: !AIVDM,1,1,,A,K5DfMB9FLsM?P00d,0*73
        length: 96
          type: 27
        repeat: 0
          mmsi: 357277000
      accuracy: 1
          raim: 0
        status: 5
           lon: 176.1817
           lat: -37.6533
         speed: 0
        course: 11
          gnss: 0
    ignored-95: 0
```
