### PR TITLE
add support for UDP, fix a few things in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ use aisgrep to get the relevant packets and aisinfo to plot the map:
 
 ## Sources
 
-My main source for protocol information is here: http://catb.org/gpsd/AIVDM.html
+My main source for protocol information is here: https://gpsd.gitlab.io/gpsd/AIVDM.html
 
 More protocol info is here: http://www.itu.int/dms_pubrec/itu-r/rec/m/R-REC-M.1371-5-201402-I!!PDF-E.pdf
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Here's an example, a simplified version of the `aist` tool, which prints
 one line per complete AIS message:
 
 
-    for sentence in sentences_from_sources(sys.argv[1:):
+    import sys
+    from simpleais import *
+
+    for sentence in sentences_from_source(sys.argv[1]):
         result = []
         if sentence.time:
             result.append(sentence.time.strftime(TIME_FORMAT))
@@ -45,7 +48,8 @@ one line per complete AIS message:
 
         print(" ".join(result))
 
-The `sentence_from_sources()` function will pull from a wide variety of sources
+
+The `sentence_from_source()` function will pull from a wide variety of sources
 (local files, serial ports, HTTP URLs), yielding only complete sentences as they
 arrive. Each sentence has a wide variety of readable information. Documented
 fields can all be referred to by name. For example, `sentence['mmsi']` or

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -998,10 +998,7 @@ def _handle_tcp_client_source(source):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.connect((ip, port))
-                s.setblocking(0)
-                # using select for timely detection of ctrl-c, even without AIS traffic
-                ready = select.select([s], [], [], 0.5)
-                if ready[0]:
+                while True:
                     line_buffer += s.recv(4096).decode('ascii')
                     lines = line_buffer.splitlines(True)
                     line_buffer = ""

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -884,7 +884,7 @@ def lines_from_source(source):
         yield from _handle_url_source(source)
     elif re.match("^:\\d{1,5}$", source):
         yield from _handle_udp_source(source)
-    elif re.match("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5}$", source):
+    elif re.match(".*:\\d{1,5}$", source):
         yield from _handle_tcp_client_source(source)
     else:
         # assume it's a file

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -882,6 +882,8 @@ def lines_from_source(source):
         yield from _handle_serial_source(source)
     elif re.match("https?://.*", source):
         yield from _handle_url_source(source)
+    elif re.match("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5}$", source):
+        yield from _handle_udp_source(source)
     else:
         # assume it's a file
         yield from _handle_file_source(source)
@@ -955,3 +957,27 @@ def _handle_file_source(source):
     with source_reader as f:
         for line in f:
             yield line
+
+
+def _handle_udp_source(source):
+    import socket
+    import select
+
+    ip, port = source.split(':')
+    if ip.endswith('.255'):
+        # use default IP for receiving UDP broadcast messages
+        ip = ''
+    port = int(port)
+
+    while True:
+        # noinspection PyBroadException
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.bind((ip, port))
+                # using select for timely detection of ctrl-c, even without AIS traffic
+                ready = select.select([s], [], [], 0.5)
+                if ready[0]:
+                    yield s.recv(4096).decode('ascii')
+        except Exception:
+            logging.getLogger().error("unexpected failure in source {}".format(source), exc_info=True)
+            time.sleep(1)

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -885,7 +885,7 @@ def lines_from_source(source):
     elif re.match("^:\\d{1,5}$", source):
         yield from _handle_udp_source(source)
     elif re.match("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5}$", source):
-        pass
+        yield from _handle_tcp_client_source(source)
     else:
         # assume it's a file
         yield from _handle_file_source(source)
@@ -976,6 +976,27 @@ def _handle_udp_source(source):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
                 s.bind((ip, port))
+                # using select for timely detection of ctrl-c, even without AIS traffic
+                ready = select.select([s], [], [], 0.5)
+                if ready[0]:
+                    yield s.recv(4096).decode('ascii')
+        except Exception:
+            logging.getLogger().error("unexpected failure in source {}".format(source), exc_info=True)
+            time.sleep(1)
+
+
+def _handle_tcp_client_source(source):
+    import socket
+    import select
+
+    ip, port = source.split(':')
+    port = int(port)
+
+    while True:
+        # noinspection PyBroadException
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.connect((ip, port))
                 # using select for timely detection of ctrl-c, even without AIS traffic
                 ready = select.select([s], [], [], 0.5)
                 if ready[0]:

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -882,8 +882,10 @@ def lines_from_source(source):
         yield from _handle_serial_source(source)
     elif re.match("https?://.*", source):
         yield from _handle_url_source(source)
-    elif re.match("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5}$", source):
+    elif re.match("^:\\d{1,5}$", source):
         yield from _handle_udp_source(source)
+    elif re.match("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5}$", source):
+        pass
     else:
         # assume it's a file
         yield from _handle_file_source(source)

--- a/simpleais/__init__.py
+++ b/simpleais/__init__.py
@@ -970,16 +970,22 @@ def _handle_udp_source(source):
         # use default IP for receiving UDP broadcast messages
         ip = ''
     port = int(port)
+    line_buffer = ""
 
     while True:
         # noinspection PyBroadException
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
                 s.bind((ip, port))
-                # using select for timely detection of ctrl-c, even without AIS traffic
-                ready = select.select([s], [], [], 0.5)
-                if ready[0]:
-                    yield s.recv(4096).decode('ascii')
+                while True:
+                    line_buffer += s.recv(4096).decode('ascii')
+                    lines = line_buffer.splitlines(True)
+                    line_buffer = ""
+                    for l in lines:
+                        if l.find('\n') != -1:
+                            yield l
+                        else:
+                            line_buffer += l
         except Exception:
             logging.getLogger().error("unexpected failure in source {}".format(source), exc_info=True)
             time.sleep(1)

--- a/tests/test_source_handling.py
+++ b/tests/test_source_handling.py
@@ -67,7 +67,7 @@ class TestSourceHandling(TestCase):
                     self.assertRaises(StopIteration, sentences.__next__)
             logs.check(('root', 'WARNING', 'skipped: "garbage data"'))
 
-    # TODO: figure out how to test serial and url sources effectively
+    # TODO: figure out how to test serial, url, and udp sources effectively
 
     def write_sample_data(self, file, compress=False):
         if compress:


### PR DESCRIPTION
This pull request extends `sentences_from_source()` to receive AIS data over UDP. Input from UDP is activated when source matches the pattern ip-address:port. 

I also fixed the example in the README, which wasn't working. And also updated the link to the AIVDM documentation as it moved a few years ago.
